### PR TITLE
Added note on common SSL error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ If you have not already installed globally, you have to download composer. Just 
 ```bash
 php -r "readfile('https://getcomposer.org/installer');" | php
 ```
+
+If that produces SSL errors (`...certificate verify failed...`), try using `wget https://getcomposer.org/installer` or downloading the file manually.
+
 Now get the required libraries to work with PhpOrient:
 ```bash
 php composer.phar --no-dev install

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ If you have not already installed globally, you have to download composer. Just 
 php -r "readfile('https://getcomposer.org/installer');" | php
 ```
 
-If that produces SSL errors (`...certificate verify failed...`), try using `wget https://getcomposer.org/installer` or downloading the file manually.
+If that produces SSL errors (`...certificate verify failed...`), try using:
+```bash
+wget https://getcomposer.org/installer
+```
+or downloading the file manually.
 
 Now get the required libraries to work with PhpOrient:
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If that produces SSL errors (`...certificate verify failed...`), try using:
 ```bash
 wget https://getcomposer.org/installer
 ```
-or downloading the file manually.
+or download the file from a browser.
 
 Now get the required libraries to work with PhpOrient:
 ```bash


### PR DESCRIPTION
Any (?) PHP built with curl support will throw errors on the `readfile()` call; even if built without `--with-curl-wrappers`. (Tested both PHP 5.6.4.) The solution should be obvious, but did cause some confusion for me, so may be worth a note.
